### PR TITLE
First attempt to add markdown support

### DIFF
--- a/src/routes/api/[username].js
+++ b/src/routes/api/[username].js
@@ -28,8 +28,20 @@ export async function get({ params, url }) {
         success: true
       }
     };
+  } else if (url.searchParams.get('style') === 'true') {
+    let result = await run(user.status, user.username);
+    result = parseMarkdown(result, false)
+    return {
+      status: 200,
+      body: {
+        username: user.username,
+        status: user.status,
+        success: true
+      }
+    };
   } else {
-    const result = await run(user.status, user.username);
+    let result = await run(user.status, user.username);
+    result = parseMarkdown(result, true)
 
     return {
       status: 200,
@@ -100,4 +112,26 @@ export async function post({ params, request }) {
   return {
     status: 401
   };
+}
+
+function parseMarkdown(parseText, remove) {
+  var rules = [
+    //bold, italics and underline rules
+    [/\*\*\s?([^\n]+)\*\*/g, (remove ? "" : "<b>$1</b>")],
+    [/__([^_]+)__/g, (remove ? "" : "<u>$1</u>")],
+    [/_([^_`]+)_/g, (remove ? "" : "<i>$1</i>")],
+    [/\*\s?([^\n]+)\*/g, (remove ? "" : "<i>$1</i>")],
+    
+    //links
+    [
+      /\[([^\]]+)\]\(([^)]+)\)/g,
+      (remove ? "" : '<a href="$2">$1</a>'),
+    ],
+  ];
+  
+  rules.forEach(([rule, template]) => {
+    parseText = parseText.replace(rule, template)
+  })
+  parseText = parseText.replace( );
+  return parseText;
 }

--- a/src/routes/dashboard.svelte
+++ b/src/routes/dashboard.svelte
@@ -49,6 +49,8 @@
       .then(res => statusOutput = res.result);
   }
 
+  async function parseMarkdown;
+
   onMount(() => {
     scratchDBPromise = fetch('https://scratchdb.lefty.one/v3/user/info/' + user.username);
   });
@@ -221,13 +223,23 @@
     <dt><code>{'{'}round <u>a (number)</u> <u>b (number)</u>}</code></dt>
       <dd>rounds <code><u>a</u></code> to the nearest <code><u>b</u></code> decimal places</dd>
   </dl>
+  <h3>Style Components</h3>
+  <p>
+    Aviate uses Markdown, a simple plain text formatting system that'll help you make your sentences <b>stand out</b>. Here's how to do it:
+  </p>
+  <dt><i>Italics</i> <code>*italics* or _italics_</code></dt>
+  <dt><b>Bold</b> <code>**bold**</code></dt>
+  <dt><u>Underline</b> <code>__underline__</code></dt>
+  <dt><a>Link</b> <code>[link](https://scratch.mit.edu)</code></dt>
+
   <h3>Examples</h3>
   <ul>
-    <li><code>I have {'{followers}'} followers on Scratch!</code>
-    <li><code>If you add 3 and 4, then multiple that by two, you get {'{mul {add 3 4} 2}'}</code>
-    <li><code>Here's a funny joke: {'{joke}'}</code>
+    <li><code>I have **{'{followers}'}** followers on Scratch!</code>
+    <li><code>If you add 3 and 4, then multiple that by two, you get __{'{mul {add 3 4} 2}'}__</code>
+    <li><code>Here's a funny joke: *{'{joke}'}*</code>
     <li><code>Think of a number between 1 and 10. What is {'{random 1 10}'}? If so, you got it right!</code>
     <li><code>{'I have {posts} forum posts, with {round {percent {posts at} {posts}} 1}% of them in the ATs.'}</code>
+    <li><code>[Totally Not Rickroll](https://www.youtube.com/watch?v=dQw4w9WgXcQ)</code>
   </ul>
 </div>
 

--- a/src/routes/dashboard.svelte
+++ b/src/routes/dashboard.svelte
@@ -49,8 +49,6 @@
       .then(res => statusOutput = res.result);
   }
 
-  async function parseMarkdown;
-
   onMount(() => {
     scratchDBPromise = fetch('https://scratchdb.lefty.one/v3/user/info/' + user.username);
   });


### PR DESCRIPTION
# Idea
I think we can add markdown support for aviate - users can add for example bold text.

# How to use it in aviate?

Just add tags like `**`, `*`, `_`, `__`, `[](<url>)`

# ToDo:
- [ ] Test it
- [ ] Show style in preview
- [ ] Maybe move markdown function to run function

# How to use it in extensions?
```js
var rules = [
  //bold, italics and underline rules
  [/\*\*\s?([^\n]+)\*\*/g, (remove ? "" : "<b>$1</b>")],
  [/__([^_]+)__/g, (remove ? "" : "<u>$1</u>")],
  [/_([^_`]+)_/g, (remove ? "" : "<i>$1</i>")],
  [/\*\s?([^\n]+)\*/g, (remove ? "" : "<i>$1</i>")],
  
  //links
  [
    /\[([^\]]+)\]\(([^)]+)\)/g,
    (remove ? "" : '<a href="$2">$1</a>'),
  ],
];

let parseText = await fetch(`https://aviateapp.eu.org/api/${username}?style=true`)).json()
parseText = escapeHTML(parseText); // escapeHTML function is in SA
rules.forEach(([rule, template]) => {
  parseText = parseText.replace(rule, template)
})
parseText = parseText.replace( );
statusEl.innerHTML = parseText;
```

@MystPi can you please accept this, so I can test it on vercel?